### PR TITLE
Fix missing feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(seek_convenience, const_fn)]
+#![feature(seek_convenience, const_fn, seek_stream_len)]
 use crc::{crc32, Hasher32};
 use indexmap::IndexMap;
 pub mod names;


### PR DESCRIPTION
Added `seek_stream_len` feature to fix error on latest Rust version